### PR TITLE
Fixed a bug where captions were not shown when only one slide was defined

### DIFF
--- a/scripts/camera.js
+++ b/scripts/camera.js
@@ -1789,7 +1789,9 @@
 						selector.eq(slideI).show().css('z-index','999').addClass('cameracurrent');
 						selector.eq(vis).css('z-index','1').removeClass('cameracurrent');
 						$('.cameraContent',fakeHover).eq(slideI).addClass('cameracurrent');
-						$('.cameraContent',fakeHover).eq(vis).removeClass('cameracurrent');
+						if (vis >= 0) {
+							$('.cameraContent',fakeHover).eq(vis).removeClass('cameracurrent');
+						}
 						
 						if($('> div', elem).eq(slideI).attr('data-video')!='hide' && $('.cameraContent.cameracurrent .imgFake',fakeHover).length ){
 							$('.cameraContent.cameracurrent .imgFake',fakeHover).click();


### PR DESCRIPTION
The captions css class 'cameracurrent' was removed, because the used selector `eq(n)` selector always returns 0 if `n` is 0 or less. So it added the class and removed it in the next line again.
