### PR TITLE
Fix bug: non-responsive moveFromBottom caption class

### DIFF
--- a/scripts/camera.js
+++ b/scripts/camera.js
@@ -1892,7 +1892,9 @@
 									});
 								} else if(tClass.indexOf("moveFromBottom") != -1) {
 									t.css({'top':h+'px','bottom':'auto'});
-									t.css('visibility','visible').delay((time/lMoveInContent)*(0.1*(ind-1))).animate({'top':pos.top},(time/lMoveInContent)*0.15,easeMove);
+									t.css('visibility','visible').delay((time/lMoveInContent)*(0.1*(ind-1))).animate({'top':pos.top},(time/lMoveInContent)*0.15,easeMove,function(){
+										t.css({top:'auto',bottom:0});
+									});
 								} else if(tClass.indexOf("fadeFromLeft") != -1) {
 									t.animate({opacity:0},0).css({'left':'-'+(w)+'px','right':'auto'});
 									t.css('visibility','visible').delay((time/lMoveInContent)*(0.1*(ind-1))).animate({'left':pos.left,opacity:1},(time/lMoveInContent)*0.15,easeMove);


### PR DESCRIPTION
moveFromBottom's animate function doesn't set {top:"auto", bottom:0} at the end of the animation
